### PR TITLE
lazily unmount the FUSE directory.

### DIFF
--- a/cmd/syncthingfuse/fuse.go
+++ b/cmd/syncthingfuse/fuse.go
@@ -247,7 +247,7 @@ func Unmount(point string) error {
 	case "darwin":
 		cmd = exec.Command("/usr/sbin/diskutil", "umount", "force", point)
 	case "linux":
-		cmd = exec.Command("fusermount", "-u", point)
+		cmd = exec.Command("fusermount", "-z", "-u", point)
 	default:
 		return errors.New("unmount: unimplemented")
 	}


### PR DESCRIPTION
`umount -z` prevents unmounting errors when the FUSE directory
is opened and syncthingfuse exits. the worse problem is that
syncthingfuse is unable to start again until someone umounts the
pending FUSE directory manually. this will happen less now.

partially fixes https://github.com/burkemw3/syncthingfuse/issues/11.
